### PR TITLE
ADD: reset filters button logic

### DIFF
--- a/pagina-maqueta/icvu.html
+++ b/pagina-maqueta/icvu.html
@@ -124,7 +124,7 @@
               <div id="reset_button"></div>
           </div>
           <div class="clear">
-            <button class="btn btn-secondary btn-sm" onclick="clear();">Limpiar filtros</button>
+            <button class="btn btn-secondary btn-sm">Limpiar filtros</button>
           </div>
       </section>
       <!--Fin filtros-->

--- a/pagina-maqueta/js/chart_google.js
+++ b/pagina-maqueta/js/chart_google.js
@@ -438,7 +438,12 @@ function downloadImageSvg(imageContainer, filename){
           }
         });
 
-        
+        // Event listener on '#clearFilters' button that selects all declared filters
+        // and resets them to their original state.
+        $('#clearFilters').on('click',function(){
+          var filters =  [TypeFilter, PopulationRangeSlider, MetropolitanaFilter, LocalizacionFilter, DistribucionFilter, DependenciaRangeSlider, PerCapitaRangeSlider]
+          filters.map( filter => filter.getControl().resetControl() )
+        })
 
 /* ESTO ES LO PENDIENTE A SUBIR  <- **/
 // Acá están las opciones del gráfico:

--- a/pagina-maqueta/js/index.js
+++ b/pagina-maqueta/js/index.js
@@ -20,10 +20,4 @@ $(function(){
 
 
   $('[data-toggle="popover"]').popover();
-
-  function clear('ordenamiento'){
-    document.getElementById("ordenamiento").reset();
-    console.log('limpiar filtros');
-  };
-
 });


### PR DESCRIPTION
Adds an event listener to `#clearFilters` that triggers a function which will iterate over the filters collection.

Another approach would be to split it into several methods:

```
var allFilters = [TypeFilter, PopulationRangeSlider, MetropolitanaFilter, LocalizacionFilter, DistribucionFilter, DependenciaRangeSlider, PerCapitaRangeSlider]

$('#clearFilters').on('click', resetFilters(allFilters) )

function resetFilters(filterCollection){
  filterCollection.map( filter => filter.getControl().resetControl() )
}
```

The advantage of this is that you can call `resetFilters` with any filter collection.
```
// When 'comuna' is not selected, define filters you want to reset. In this case we're ommiting TypeFilter
var otherFilters = [PopulationRangeSlider, MetropolitanaFilter, LocalizacionFilter, DistribucionFilter, DependenciaRangeSlider, PerCapitaRangeSlider]

resetFilters(otherFilters)
```

Just make sure the filters are in the function's scope.